### PR TITLE
Added code to report to the caller of iksemel whether the jabber server mandates TLS connection

### DIFF
--- a/include/iksemel.h
+++ b/include/iksemel.h
@@ -291,6 +291,7 @@ int iks_start_sasl (iksparser *prs, enum ikssasltype type, char *username, char 
 #define IKS_STREAM_BIND                       4
 #define IKS_STREAM_SASL_PLAIN                 8
 #define IKS_STREAM_SASL_MD5                  16
+#define IKS_STREAM_STARTTLS_REQUIRED         32
 
 typedef struct iksid_struct {
 	char *user;

--- a/src/jabber.c
+++ b/src/jabber.c
@@ -313,16 +313,17 @@ iks_sasl_mechanisms (iks *x)
 static int
 iks_starttls_options (iks *x)
 {
-        int options = IKS_STREAM_STARTTLS;
+	int options = IKS_STREAM_STARTTLS;
 
-        while (x) {
-                if (!iks_strcmp(iks_name(x), "required")) {
-                        options |= IKS_STREAM_STARTTLS_REQUIRED;
-                }
-                x = iks_next_tag(x);
-        }
+	while (x) {
+		if (!iks_strcmp(iks_name(x), "required")) {
+			options |= IKS_STREAM_STARTTLS_REQUIRED;
+		}
 
-        return options;
+		x = iks_next_tag(x);
+	}
+
+	return options;
 }
 
 int
@@ -335,9 +336,7 @@ iks_stream_features (iks *x)
 	for (x = iks_child(x); x; x = iks_next_tag(x)) {
 		if (!iks_strcmp(iks_name(x), "starttls")) {
 			features |= iks_starttls_options(iks_child(x));
-    } else if (!iks_strcmp(iks_name(x), "starttls"))
-			features |= IKS_STREAM_STARTTLS;
-		else if (!iks_strcmp(iks_name(x), "bind"))
+		} else if (!iks_strcmp(iks_name(x), "bind"))
 			features |= IKS_STREAM_BIND;
 		else if (!iks_strcmp(iks_name(x), "session"))
 			features |= IKS_STREAM_SESSION;

--- a/src/jabber.c
+++ b/src/jabber.c
@@ -310,6 +310,21 @@ iks_sasl_mechanisms (iks *x)
 	return sasl_mech;
 }
 
+static int
+iks_starttls_options (iks *x)
+{
+        int options = IKS_STREAM_STARTTLS;
+
+        while (x) {
+                if (!iks_strcmp(iks_name(x), "required")) {
+                        options |= IKS_STREAM_STARTTLS_REQUIRED;
+                }
+                x = iks_next_tag(x);
+        }
+
+        return options;
+}
+
 int
 iks_stream_features (iks *x)
 {
@@ -317,8 +332,10 @@ iks_stream_features (iks *x)
 
 	if (iks_strcmp(iks_name(x), "stream:features"))
 		return 0;
-	for (x = iks_child(x); x; x = iks_next_tag(x))
-		if (!iks_strcmp(iks_name(x), "starttls"))
+	for (x = iks_child(x); x; x = iks_next_tag(x)) {
+		if (!iks_strcmp(iks_name(x), "starttls")) {
+			features |= iks_starttls_options(iks_child(x));
+    } else if (!iks_strcmp(iks_name(x), "starttls"))
 			features |= IKS_STREAM_STARTTLS;
 		else if (!iks_strcmp(iks_name(x), "bind"))
 			features |= IKS_STREAM_BIND;
@@ -326,5 +343,6 @@ iks_stream_features (iks *x)
 			features |= IKS_STREAM_SESSION;
 		else if (!iks_strcmp(iks_name(x), "mechanisms"))
 			features |= iks_sasl_mechanisms(iks_child(x));
+  }
 	return features;
 }


### PR DESCRIPTION
This code informs the caller of the library whether the jabber server mandates that TLS be used.
